### PR TITLE
Assert statement added

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,8 @@
             "args": [
                 //"-c",
                 // "interpreter-test.lang",
-                "sample_test.lang",
+                // "sample_test.lang",
+                "assertions.lang",
                 // "-tree",
                 // "interpreter-test.txt"
                 // "ast-test.lang"

--- a/bin/assertions.lang
+++ b/bin/assertions.lang
@@ -1,0 +1,20 @@
+func main() {
+    assert(1);
+    assert(1 == 1);
+    
+    declare x: int;
+    assert(x == 0);
+
+    x = 10;
+    assert(x == 10);
+
+    if (1) {
+        declare x: int;
+        assert(x == 0);
+    } else {
+        assert(0);
+    }
+
+    // Needs to fail
+    assert(x*x == -1);
+}

--- a/bin/assertions.lang
+++ b/bin/assertions.lang
@@ -15,6 +15,6 @@ func main() {
         assert(0);
     }
 
-    // Needs to fail
-    assert(x*x == -1);
+    // Here goes the failing assertion:
+    assert(x == x); assert(x*x == -1);
 }

--- a/bin/sample_test.lang
+++ b/bin/sample_test.lang
@@ -95,4 +95,6 @@ func main() {
         print(-100 + i);
         i = i + 1;
     }
+
+    assert(2 * 2 == 2 + 2);
 }

--- a/custom-codegens/visitor_types.txt
+++ b/custom-codegens/visitor_types.txt
@@ -20,4 +20,5 @@ Conditional;conditional
 PreLoop;pre_loop
 BreakStatement;loop_break
 ContinueStatement;loop_continue
+AssertStatement;assertion
 Program;program

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,7 @@ add_executable(
     grammar-entities/Assignment.cpp
     grammar-entities/BreakStatement.cpp
     grammar-entities/ContinueStatement.cpp
+    grammar-entities/AssertStatement
     
     grammar-entities/expressions/AddExpression.cpp
     grammar-entities/expressions/SubExpression.cpp

--- a/src/forward_declarations.hh
+++ b/src/forward_declarations.hh
@@ -13,6 +13,7 @@ class Conditional;
 class PreLoop;
 class BreakStatement;
 class ContinueStatement;
+class AssertStatement;
 
 class Program;
 

--- a/src/grammar-entities/AssertStatement.cpp
+++ b/src/grammar-entities/AssertStatement.cpp
@@ -1,8 +1,12 @@
 #include "AssertStatement.hh"
 
 AssertStatement::AssertStatement(
-    std::shared_ptr<BaseExpression> expression
-) : expression_(expression) {}
+    std::shared_ptr<BaseExpression> expression,
+    yy::location loc
+) : expression_(expression)
+{
+    location = loc;
+}
 
 void AssertStatement::Accept(BaseVisitor* visitor) {
     visitor->Visit(this);

--- a/src/grammar-entities/AssertStatement.cpp
+++ b/src/grammar-entities/AssertStatement.cpp
@@ -1,0 +1,9 @@
+#include "AssertStatement.hh"
+
+AssertStatement::AssertStatement(
+    std::shared_ptr<BaseExpression> expression
+) : expression_(expression) {}
+
+void AssertStatement::Accept(BaseVisitor* visitor) {
+    visitor->Visit(this);
+}

--- a/src/grammar-entities/AssertStatement.hh
+++ b/src/grammar-entities/AssertStatement.hh
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "Statement.hh"
+#include "expressions/BaseExpression.hh"
+
+class AssertStatement : public Statement {
+public:
+    std::shared_ptr<BaseExpression> expression_;
+
+    AssertStatement(std::shared_ptr<BaseExpression> expression);
+    void Accept(BaseVisitor* visitor);
+};

--- a/src/grammar-entities/AssertStatement.hh
+++ b/src/grammar-entities/AssertStatement.hh
@@ -7,6 +7,9 @@ class AssertStatement : public Statement {
 public:
     std::shared_ptr<BaseExpression> expression_;
 
-    AssertStatement(std::shared_ptr<BaseExpression> expression);
+    AssertStatement(
+        std::shared_ptr<BaseExpression> expression,
+        yy::location loc
+    );
     void Accept(BaseVisitor* visitor);
 };

--- a/src/includes_for_parser.hh
+++ b/src/includes_for_parser.hh
@@ -9,6 +9,7 @@
 #include "grammar-entities/PreLoop.hh"
 #include "grammar-entities/BreakStatement.hh"
 #include "grammar-entities/ContinueStatement.hh"
+#include "grammar-entities/AssertStatement.hh"
     
 #include "grammar-entities/expressions/AddExpression.hh"
 #include "grammar-entities/expressions/SubExpression.hh"

--- a/src/inputs/parser.y
+++ b/src/inputs/parser.y
@@ -365,7 +365,8 @@ loop_continue:
 
 assertion:
    "assert" "(" expression ")" ";" {
-        $$ = std::make_shared<AssertStatement>($3);
+        const auto loc = driver.locman.last_assert;
+        $$ = std::make_shared<AssertStatement>($3, loc);
    }
 
 

--- a/src/inputs/parser.y
+++ b/src/inputs/parser.y
@@ -106,6 +106,7 @@
     BREAK "break"
     CONTINUE "continue"
     PRINT "print"
+    ASSERT "assert"
     INT_TYPE "int_type"
     EQ "=="
     NE "!="
@@ -147,6 +148,7 @@
 %nterm <std::shared_ptr<PreLoop>> pre_loop
 %nterm <std::shared_ptr<BreakStatement>> loop_break
 %nterm <std::shared_ptr<ContinueStatement>> loop_continue
+%nterm <std::shared_ptr<AssertStatement>> assertion
 
 
 
@@ -319,6 +321,9 @@ statement:
     | loop_continue {
         $$ = $1;
     }
+    | assertion {
+        $$ = $1;
+    }
     
 
 
@@ -357,6 +362,11 @@ loop_continue:
         const auto loc = driver.locman.last_break_continue;
         $$ = std::make_shared<ContinueStatement>(loc);
     }
+
+assertion:
+   "assert" "(" expression ")" ";" {
+        $$ = std::make_shared<AssertStatement>($3);
+   }
 
 
 // Grammar info section is surrounded by %% from both sides

--- a/src/inputs/scanner.l
+++ b/src/inputs/scanner.l
@@ -116,6 +116,7 @@ comment \/\/.*?\n
                 return yy::parser::make_CONTINUE(loc);
               }
 "print"       return yy::parser::make_PRINT(loc);
+"assert"      return yy::parser::make_ASSERT(loc);
 "int"         return yy::parser::make_INT_TYPE(loc);
 "=="          return yy::parser::make_EQ(loc);
 "!="          return yy::parser::make_NE(loc);

--- a/src/inputs/scanner.l
+++ b/src/inputs/scanner.l
@@ -116,7 +116,10 @@ comment \/\/.*?\n
                 return yy::parser::make_CONTINUE(loc);
               }
 "print"       return yy::parser::make_PRINT(loc);
-"assert"      return yy::parser::make_ASSERT(loc);
+"assert"      {
+                driver.locman.matched_assert();
+                return yy::parser::make_ASSERT(loc);
+              }
 "int"         return yy::parser::make_INT_TYPE(loc);
 "=="          return yy::parser::make_EQ(loc);
 "!="          return yy::parser::make_NE(loc);

--- a/src/utils/location_manager.cpp
+++ b/src/utils/location_manager.cpp
@@ -15,6 +15,7 @@ void LocationManager::move_down(int lines_cnt) {
 void LocationManager::move_forward(int token_length) {
     current.columns(token_length);
 }
+
 void LocationManager::matched_assign() {
     last_assign_id = last_id;
 }
@@ -23,4 +24,7 @@ void LocationManager::matched_id() {
 }
 void LocationManager::matched_break_continue() {
     last_break_continue = current;
+}
+void LocationManager::matched_assert() {
+    last_assert = current;
 }

--- a/src/utils/location_manager.hh
+++ b/src/utils/location_manager.hh
@@ -8,13 +8,16 @@ struct LocationManager {
     yy::location last_id;
     yy::location last_assign_id;
     yy::location last_break_continue;
+    yy::location last_assert;
 
     void initialize(yy::location::filename_type* f);
 
     void step();
     void move_down(int lines_cnt);
     void move_forward(int token_length);
+
     void matched_assign();
     void matched_id();
     void matched_break_continue();
+    void matched_assert();
 };

--- a/src/visitors/BaseVisitor.hh
+++ b/src/visitors/BaseVisitor.hh
@@ -27,6 +27,7 @@ public:
     virtual void Visit(PreLoop* loop) = 0;
     virtual void Visit(BreakStatement* loop_break) = 0;
     virtual void Visit(ContinueStatement* loop_continue) = 0;
+    virtual void Visit(AssertStatement* assertion) = 0;
 
     virtual void Visit(Program* program) = 0;
 };

--- a/src/visitors/BreakContinueVisitor.cpp
+++ b/src/visitors/BreakContinueVisitor.cpp
@@ -103,6 +103,10 @@ void BreakContinueVisitor::Visit(ContinueStatement* loop_continue) {
     }
 }
 
+void BreakContinueVisitor::Visit(AssertStatement*) {
+    
+}
+
 void BreakContinueVisitor::Visit(Program* program) {
     program->statements_->Accept(this);
 }

--- a/src/visitors/BreakContinueVisitor.hh
+++ b/src/visitors/BreakContinueVisitor.hh
@@ -33,5 +33,6 @@ public:
     void Visit(PreLoop* pre_loop) override;
     void Visit(BreakStatement* loop_break) override;
     void Visit(ContinueStatement* loop_continue) override;
+    void Visit(AssertStatement* assertion) override;
     void Visit(Program* program) override;
 };

--- a/src/visitors/Interpreter.cpp
+++ b/src/visitors/Interpreter.cpp
@@ -232,6 +232,18 @@ void Interpreter::Visit(ContinueStatement*) {
     current_flow = ControlFlowType::Continue;
 }
 
+void Interpreter::Visit(AssertStatement* assertion) {
+    // Compute the expression
+    assertion->expression_->Accept(this);
+
+    if (!tos_value_) {
+        // Assertion failed
+        throw std::runtime_error(
+            "Assertion failed!"
+        );
+    }
+}
+
 void Interpreter::Visit(Program* program) {
     // Interpret its statements
     program->statements_->Accept(this);

--- a/src/visitors/Interpreter.cpp
+++ b/src/visitors/Interpreter.cpp
@@ -238,8 +238,9 @@ void Interpreter::Visit(AssertStatement* assertion) {
 
     if (!tos_value_) {
         // Assertion failed
+        const auto loc = loc_to_str(assertion->location);
         throw std::runtime_error(
-            "Assertion failed!"
+            "Assertion failed! (" + loc + ")"
         );
     }
 }

--- a/src/visitors/Interpreter.hh
+++ b/src/visitors/Interpreter.hh
@@ -45,6 +45,7 @@ public:
     void Visit(PreLoop* loop) override;
     void Visit(BreakStatement* loop_break) override;
     void Visit(ContinueStatement* loop_continue) override;
+    void Visit(AssertStatement* assertion) override;
 
     void Visit(Program* program) override;
 

--- a/src/visitors/PrintVisitor.cpp
+++ b/src/visitors/PrintVisitor.cpp
@@ -208,6 +208,15 @@ void PrintVisitor::Visit(ContinueStatement*) {
     stream_ << "ContinueStatement\n";
 }
 
+void PrintVisitor::Visit(AssertStatement* assertion) {
+    PrintTabs();
+    stream_ << "AssertStatement\n";
+
+    ++num_tabs_;
+    assertion->expression_->Accept(this);
+    --num_tabs_;
+}
+
 void PrintVisitor::Visit(Program* program) {
     PrintTabs();
     stream_ << "Program: \n";

--- a/src/visitors/PrintVisitor.hh
+++ b/src/visitors/PrintVisitor.hh
@@ -40,6 +40,7 @@ public:
     void Visit(PreLoop* loop) override;
     void Visit(BreakStatement* loop_break) override;
     void Visit(ContinueStatement* loop_continue) override;
+    void Visit(AssertStatement* assertion) override;
 
     void Visit(Program* program) override;
 };

--- a/src/visitors/VisibilityCheckVisitor.cpp
+++ b/src/visitors/VisibilityCheckVisitor.cpp
@@ -127,6 +127,10 @@ void VisibilityCheckVisitor::Visit(ContinueStatement*) {
     // No code
 }
 
+void VisibilityCheckVisitor::Visit(AssertStatement* assertion) {
+    assertion->expression_->Accept(this);
+}
+
 void VisibilityCheckVisitor::Visit(Program* program) {
     program->statements_->Accept(this);
 }

--- a/src/visitors/VisibilityCheckVisitor.hh
+++ b/src/visitors/VisibilityCheckVisitor.hh
@@ -34,5 +34,6 @@ public:
     void Visit(PreLoop* loop) override;
     void Visit(BreakStatement* loop_break) override;
     void Visit(ContinueStatement* loop_continue) override;
+    void Visit(AssertStatement* assertion) override;
     void Visit(Program* program) override;
 };


### PR DESCRIPTION
Now we can make runtime assertions that abort the execution if the expression doesn't evaluate to `true`.

I'll likely rewrite the tests to use this statement in as many places as possible instead of just printing *everything*...